### PR TITLE
Small fix in oncoprint matrix preparation

### DIFF
--- a/R/wrangle.R
+++ b/R/wrangle.R
@@ -579,7 +579,6 @@ prepare_dataframe_for_oncoprint <- function(variant_data_frame, id_column="sampl
     oncoprint_matrix[is.na(oncoprint_matrix)] = ''
     rownames(oncoprint_matrix) = oncoprint_matrix[, 1]
     oncoprint_matrix = oncoprint_matrix[, -1]
-    oncoprint_matrix=  oncoprint_matrix[, -ncol(oncoprint_matrix)]
     oncoprint_matrix = t(as.matrix(oncoprint_matrix))
 
     return(oncoprint_matrix)


### PR DESCRIPTION
This removes a line of code that would remove the last column of the prepared matrix. 