### PR TITLE
Add documentation, improve parsers

### DIFF
--- a/R/cvo.R
+++ b/R/cvo.R
@@ -3,35 +3,56 @@
 #' @description Read in a CombinedVariantOutput.tsv file
 #'
 #' @param cvo_file_path a file path to a CombinedVariantOutput.tsv file
+#' @param local_app specifies whether quality metrics are coming from local app
 #'
 #' @return A combined.variant.output object
 #' @export
 #'
 #' @examples
-cvo <- function(cvo_file_path){
-  new_combined_variant_output(cvo_file_path)
+cvo <- function(cvo_file_path, local_app=FALSE){
+  new_combined_variant_output(cvo_file_path, local_app)
 }
 
 #' Constructor function for combined.variant.output objects
 #' Not to be called directly
 #'
 #' @param cvo_file_path a file path to a CombinedVariantOutput.tsv file
+#' @param local_app specifies whether quality metrics are coming from local app
 #'
 #' @return A combined.variant.output object
-new_combined_variant_output <- function(cvo_file_path) {
+new_combined_variant_output <- function(cvo_file_path, local_app=FALSE) {
+
+  ANALYSIS_DETAILS_STRING <- 'Analysis Details'
+  GENE_AMP_STRING <- 'Gene Amplifications'
+  PERCENT_MSI_STRING <- 'Percent Unstable MSI Sites'
 
   cvo_file <- readr::read_file(cvo_file_path)
   split_cvo_string <- stringr::str_split(string = cvo_file, pattern = "\\[") %>% unlist()
 
+  # parse analysis details, sequencing run details, TMB, and MSI part of provided CombinedVariantOutput file
+  start_info <- which(grepl(ANALYSIS_DETAILS_STRING,split_cvo_string))
+  end_info <- which(grepl(PERCENT_MSI_STRING, split_cvo_string))
+
   # handle the parts of the file that are structured as key-value pairs
   # i.e. metadata and TMB/MSI sections
-  records <- purrr::map(split_cvo_string[2:5], parse_cvo_record)
+  records <- purrr::map(split_cvo_string[start_info:end_info], parse_cvo_record)
   names(records) <- c("analysis_details", "sequencing_run_details", "tmb", "msi")
 
   # handle the parts of the file that are structured as tabular data
   # i.e. gene amplifications, splice variants, fusions, and small variants
-  tables <- purrr::map(split_cvo_string[6:9], parse_cvo_table)
-  names(tables) <- c("gene_amplifications", "splice_variants", "fusions", "small_variants")
+  start_data <- pmatch(GENE_AMP_STRING,split_cvo_string)
+  end_data <- length(split_cvo_string)
+
+  tables <- purrr::map(split_cvo_string[start_data:end_data], parse_cvo_table)
+
+  # the number of tables is different between local app and DRAGEN analysis pipeline
+  print(local_app)
+  if (local_app) {
+    names(tables) <- c("gene_amplifications", "splice_variants", "fusions", "small_variants")
+  }
+  else {
+    names(tables) <- c("gene_amplifications", "splice_variants", "fusions", "exon_level_cnvs", "small_variants")
+  }
 
   return(structure(c(records, tables), class = "combined.variant.output"))
 }
@@ -45,18 +66,18 @@ validate_tso500 <- function() {}
 
 #' Read in a batch of CombinedVariantOutput.tsv files into a list
 #'
-#' @param cvo_directory a file path to a directory containing one of more
-#' CombinedVariantOutput.tsv files
+#' @param cvo_directory a file path to a directory containing one of more CombinedVariantOutput.tsv files
+#' @param local_app specifies whether quality metrics are coming from local app
 #'
 #' @return A named list of combined.variant.output objects
 #' @export
-read_cvo_data <- function(cvo_directory){
+read_cvo_data <- function(cvo_directory, local_app=FALSE){
   cvo_files <- list.files(
     path = cvo_directory,
     pattern = "*CombinedVariantOutput.tsv",
     full.names = TRUE
   )
-  cvo_data <- map(cvo_files, cvo)
+  cvo_data <- map(cvo_files, cvo, local_app)
   names(cvo_data) <- map(cvo_data, ~ .x$analysis_details$pair_id)
   cvo_data
 }

--- a/R/cvo.R
+++ b/R/cvo.R
@@ -46,7 +46,6 @@ new_combined_variant_output <- function(cvo_file_path, local_app=FALSE) {
   tables <- purrr::map(split_cvo_string[start_data:end_data], parse_cvo_table)
 
   # the number of tables is different between local app and DRAGEN analysis pipeline
-  print(local_app)
   if (local_app) {
     names(tables) <- c("gene_amplifications", "splice_variants", "fusions", "small_variants")
   }

--- a/R/qualitymetrics.R
+++ b/R/qualitymetrics.R
@@ -35,10 +35,11 @@ new_combined_quality_metrics_output <- function(metrics_file_path, local_app=FAL
   tables <- purrr::map(split_qmo_string[3:11], parse_qmo_table)
 
   # the order of tables is different between local app and DRAGEN analysis pipeline
-  names(tables) <- c("run_qc_metrics", "analysis_status", "dna_qc_metrics", "dna_qc_metrics_snvtmb", "dna_qc_metrics_msi", "dna_qc_metrics_cnv", "rna_qc_metrics", "dna_expanded_metrics", "rna_expanded_metrics")
-  
   if (local_app) {
     names(tables) <- c("run_qc_metrics", "analysis_status", "dna_qc_metrics", "dna_qc_metrics_snvtmb", "dna_qc_metrics_msi", "dna_qc_metrics_cnv", "dna_expanded_metrics", "rna_qc_metrics", "rna_expanded_metrics")
+  }
+  else {
+    names(tables) <- c("run_qc_metrics", "analysis_status", "dna_qc_metrics", "dna_qc_metrics_snvtmb", "dna_qc_metrics_msi", "dna_qc_metrics_cnv", "rna_qc_metrics", "dna_expanded_metrics", "rna_expanded_metrics")
   }
 
   return(structure(c(records, tables), class = "combined.quality.metrics.output"))

--- a/R/qualitymetrics.R
+++ b/R/qualitymetrics.R
@@ -66,8 +66,11 @@ read_qmo_data <- function(qmo_directory, local_app=FALSE){
     pattern = "*MetricsOutput.tsv",
     full.names = TRUE
   )
-  qmo_data <- map(qmo_files, qualitymetrics, local_app)
-  names(qmo_data) <- map(qmo_data, ~ .x$header$output_time)
+  
+  qmo_data <- map(qmo_files, qualitymetrics, local_app) %>%
+    set_names(str_remove(basename(qmo_files), "\\.tsv$")) 
+  #names(qmo_data) <- map(qmo_data, ~ .x$header$output_time)
+
   qmo_data
 }
 

--- a/R/write.R
+++ b/R/write.R
@@ -122,26 +122,26 @@ ${tso500_data}"
   DATA_STRING <- '[Data]'
   
   # Read text file into string
-  cvo_file <- readr::read_file(samplesheet)
-  split_cvo_string <- stringr::str_split(string = cvo_file, pattern = "\r\n") %>% unlist()
+  samplesheet_file <- readr::read_file(samplesheet)
+  split_samplesheet_string <- stringr::str_split(string = samplesheet_file, pattern = "\r\n") %>% unlist()
   
   # parse header part of provided sample sheet
-  start_header <- pmatch(HEADER_STRING,split_cvo_string) + 1
-  end_header <- which(grepl(CHEMISTRY_STRING, split_cvo_string))
-  header <- read.csv(text=split_cvo_string[start_header:end_header],header=FALSE) %>%
+  start_header <- pmatch(HEADER_STRING, split_samplesheet_string) + 1
+  end_header <- which(grepl(CHEMISTRY_STRING, split_samplesheet_string))
+  header <- read.csv(text=split_samplesheet_string[start_header:end_header],header=FALSE) %>%
     purrr::discard(~all(is.na(.))) %>%
     pivot_wider(names_from=V1, values_from=V2)
   
   # parse settings part of provided sample sheet
-  start_settings <- pmatch(SETTINGS_STRING,split_cvo_string) + 1
-  end_settings <- which(grepl(OVERRIDE_CYCLES_STRING, split_cvo_string))
-  settings <- read.csv(text=split_cvo_string[start_settings:end_settings],header=FALSE) %>%
+  start_settings <- pmatch(SETTINGS_STRING, split_samplesheet_string) + 1
+  end_settings <- which(grepl(OVERRIDE_CYCLES_STRING, split_samplesheet_string))
+  settings <- read.csv(text=split_samplesheet_string[start_settings:end_settings],header=FALSE) %>%
     purrr::discard(~all(is.na(.))) %>%
     pivot_wider(names_from=V1, values_from=V2)
   
   # prase data part of provided sample sheet
-  start_data <- pmatch(DATA_STRING,split_cvo_string) + 1
-  data <- read.csv(text=split_cvo_string[start_data:length(split_cvo_string)])
+  start_data <- pmatch(DATA_STRING, split_samplesheet_string) + 1
+  data <- read.csv(text=split_samplesheet_string[start_data:length(split_samplesheet_string)])
   
   # transform bclconvert data
   bclconvert_data <- data %>%

--- a/README.md
+++ b/README.md
@@ -1,104 +1,258 @@
-# TSO500R
-
-An R package for importing and working with CombinedVariantOutput.csv files produced by TSO500 local app.
+# TSO500R(eader)
 
 ## Installation
 
-Clone the repo locally and run:
+Clone the repository and run:
 
 ```r
+# Install TS500R from local clone
 install.packages("/path/to/TSO500R", repos = NULL)
 ```
 
+## Overview
+
+*TSO500R(eader)* is an R package developed for Illumina TSO500 data. It can be used for importing and processing of files produced by the Illumina [TSO500 DRAGEN analysis pipeline](https://support-docs.illumina.com/SW/DRAGEN_TSO500_v2.1/Content/SW/FrontPages/DRAGENTSO500_v2.1.htm) and the [LocalApp](https://emea.support.illumina.com/content/dam/illumina-support/documents/documentation/software_documentation/trusight/trusight-oncology-500/trusight-oncology-500-local-app-v2.2-user-guide-1000000137777-01.pdf).
+
+The package provides different functions for parsing the various output files produced by the Illumina pipelines. This includes the quality control files as well as the analysis outputs. Besides, it offers functionality to integrate the different result types, e.g. small variants and amplifications.
+
+Other features include functions for basic plotting and export functionality for writing `RData` objects or to generate DRAGEN analysis pipeline samplesheets.
+
 ## Usage
 
-TSO500R features an API for interaction with the data in each section of the TSO500 input and output files. First load the package:
+TSO500R provides an API for interaction with most of the output files produced by the TSO500 analysis pipeline. In addition the data in each section of the quality control file (`MetricsOutput`) and the main output file of the TSO500 analysis, the `CombinedVariantOutput.tsv` file, can be read in separately.
 
 ```r
+# load the tso500R(eader) package
 library(tso500R)
 ```
 
-### Loading data
+- [Loading MetricsOutput Data](#loading-metricsoutput-data)
+- [Loading CombinedVariantOutput Datas](#loading-combinedvariantoutput-data)
+  - [Accessing Analysis Details](#accessing-analysis-details)
+  - [Accessing TMB and MSI Metrics](#accessing-tmb-and-msi-metrics)
+  - [Accessing Small Variants](#accessing-small-variants)
+- [Integration of Data](#integration-of-data)
+- [Plotting](#plotting)
+- [Other Convenience Functions](#other-convenience-functions)
 
-To load a batch of CombinedVariantOutput.tsv files, run the following command on the directory containing the files:
+
+### Loading MetricsOutput Data
+
+In order to load the `MetricsOutput.tsv` file or multiple such output files of a DRAGEN analysis run, that contains all quality control metrics of a run and all included samples, use the following code:
 
 ```r
-cvo_data_dir <- "test_data/cvo_files/211110_A01295_0033_AHLHC5DRXY_TSO500/"
-cvo_data <- read_cvo_data(cvo_data_dir)
+# load the MetricsOutput.tsv file in a specific folder
+tso500_data_dir <- "/path/to/your/TSO500/analysis/output/data/"
+qmo_data <- read_qmo_data(test_path)
 ```
 
-This will produce a list of `combined.variant.output` objects, which can be further processed. Each section in the CombinedVariantOutput file can be accessed with standard list indexing; for example:
+In case you want to read in data that resulted from a `LocalApp` run, you need to set `local_app=TRUE` due to the (slight) differences between the file formats:
 
 ```r
-
+# load the MetricsOutput.tsv file of a LocalApp run in a specific folder
+tso500_data_dir <- "/path/to/your/TSO500/analysis/output/data/"
+qmo_data <- read_qmo_data(test_path, local_app=TRUE)
 ```
 
-### TMB/MSI metrics
-
-Run the following function to extract TMB/MSI data from the batch data:
+This will produce a list of `combined.quality.metrics.output` objects, which can be further processed and contain all the information as given in the parsed files. Each section in the `CombinedVariantOutput` file can be accessed with standard list indexing. The `combined.quality.metrics.output` object in the last can be accessed via the corresponding file name (without extension). This will therfore probably be `MetricsOutput` in case you read in a metrics file of all samples of a run and will include sample identifiers (`sample1_MetricsOutput`) if you want to read in individual metrics file.
 
 ```r
+# access the header information of a specific MetricsOutput file
+qmo_data$filename$header
+
+# access the qc metrics on DNA of a specific MetricsOutput file
+qmo_data$filename$dna_qc_metrics
+
+# access the qc metrics on DNA MSI of a specific MetricsOutput file
+qmo_data$filename$dna_qc_metrics_msi
+```
+
+The available sections that can be accessed are the following: `header`, `notes`, `run_qc_metrics`, `analysis_status`, `dna_qc_metrics`, `dna_qc_metrics_snvtmb`, `dna_qc_metrics_msi`, `dna_qc_metrics_cnv`, `rna_qc_metrics`, `dna_expanded_metrics`, and `rna_expanded_metrics` 
+
+*TSO500R(eader)* also provides convenience functions to access the data from all individual tables given in a `MetricsOutput` file:
+
+```r
+# get a data frame with all qc metrics on CNVs for all samples and the given recommended thresholds
+read_dna_qc_metrics_cnv(qmo_data)
+
+# get a data frame with the expanded dna qc metrics for all samples and the given recommended thresholds
+read_dna_expanded_metrics(qmo_data)
+```
+These data frames provide the metrics for one sample per row.
+
+Please refer to the [manual](https://github.com/apeltzer/TSO500R/tree/main/man) for a complete list of functions.
+
+### Loading CombinedVariantOutput Data
+
+To load all `CombinedVariantOutput.tsv` files of a DRAGEN analysis run in a specified folder, run the following command on the directory containing the files:
+
+```r
+# load all CombinedVariantOutput.tsv files of a LocalApp run in a specific folder
+cvo_data_dir <- "/path/to/your/TSO500/analysis/output/data/"
+cvo_data <- read_cvo_data(tso500_data_dir)
+```
+
+In case you want to read in data that resulted from a `LocalApp` run, you need to set `local_app=TRUE` due to the (slight) differences between the file formats:
+
+```r
+# load all CombinedVariantOutput.tsv files in a specific folder
+cvo_data_dir <- "/path/to/your/TSO500/analysis/output/data/"
+cvo_data <- read_cvo_data(tso500_data_dir, local_app=TRUE)
+```
+
+This will produce a list of `combined.variant.output` objects, which can be further processed and contain all the information as given in the parsed files. Each section in the `CombinedVariantOutput` file can be accessed with standard list indexing. The individual `combined.variant.output` objects in the list can be accessed via the `PairID` as given in the `CombinedVariantOutput.tsv` file.
+
+```r
+# access analysis detail of sample1
+cvo_data$sample1$sequencing_run_details
+
+# access small variants of sample2
+cvo_data$sample2$small_variants
+```
+
+The available sections are the following: `analysis_details`, `sequencing_run_details`, `tmb`, `msi`, `fusions`, `gene_amplifications`, `splice_variants`, and `small_variants`
+
+#### Accessing Analysis Details
+
+You can also use a convenience function to retrieve the analysis details for every samples the `CombinedVariantOutput.tsv` file has been parsed for:
+
+```r 
+# get data frame with analysis details for every sample in list of CVO objects 
+get_analysis_details_df(cvo_data)
+```
+
+The same can be done for the sequencing run details using the corresponding function `get_sequencing_run_details_df`.
+
+#### Accessing TMB and MSI Metrics
+
+You can use the following function to extract TMB/MSI data from the list of `combined.variant.output` objects:
+
+```r
+# get TMB and MSI metrics from the CombinedVariantOutput.tsv files of all samples
 tmb_msi_df <- get_metrics_df(cvo_data)
 ```
 
-This will produce a data frame with TMB/MSI metrics, per sample.
+This will produce a dataframe with TMB/MSI metrics given in `CombinedVariantOutput.tsv` files and the corresponding sample identifiers. The metrics given as columns are the following: `total_tmb`, `coding_region_size_in_megabases`, `number_of_passing_eligible_variants`, `usable_msi_sites`, `total_msi_sites_unstable`, and `percent_unstable_msi_sites`
 
-### Small variants
-
-You can also extract all of the small variant data across all of the objects. The following function will return a `data.frame` of small variants:
+The TSO500 analysis using `LocalApp` or the DRAGEN pipeline also provides additional files with details on the TMB. We also provide parser functions for them.
 
 ```r
+tmb_directory <- "/path/to/your/TSO500/analysis/output/data/"
+
+# read in a batch of TMB_trace.tsv files into a data frame
+tmb_trace_data <- read_tmb_trace_data(tmb_directory)
+
+# read in a batch of *tmb.json files into a data frame
+tmb_details <- read_tmb_details_data(tmb_directory)
+```
+
+#### Accessing Small Variants 
+
+You can also extract all reported small variants across all of the `combined.variant.output` objects:
+
+```r
+# get small variants from the CombinedVariantOutput.tsv files of all samples
 small_variant_df <- read_small_variants(cvo_data)
 ```
 
-#### Filtering/processing
+This will produce a dataframe with small variants given in `CombinedVariantOutput.tsv` files and the corresponding sample identifiers.
 
-A processing/filtering function is available, which performs the following:
+The same is possible for genetic rearrangements:
 
-  1. filters for variants that:
-   - have a consequence in a pre-defined list
-   - are present with depth > 0
-  2. extracts NP ID and protein information from the P Dot-notation column
-  3. adds columns to faciliate addition of reference data
+```r
+# get data frame with amplifications from the CombinedVariantOutput.tsv files of all samples
+read_gene_amplifications(cvo_data)
+
+# get data frame with fusions from the CombinedVariantOutput.tsv files of all samples
+read_fusions(cvo_data)
+
+# get data frame with splice variants from the CombinedVariantOutput.tsv files of all samples
+read_splice_variants(cvo_data)
+```
+
+### Integration of Data
+
+We provide different functions to enrich the data frame containing small variant data information with other types of data.
+
+```r 
+# add information given in Illumina TMB trace table to small variant data frame
+small_variants_with_tmb_info <- small_variant_df %>%
+  add_tmb_variant_data(tmb_trace_data)
+
+# adds amplifications to small variant data frame
+small_variants_with_amps <- small_variant_df %>%
+  add_amplification_data(read_gene_amplifications(cvo_data))
+```
+
+### Filtering and Processing
+
+We also provide processing/filtering functions. If you want to do the following filtering steps, please use the function `process_small_variant_data` on your data frame with small variants.
+
+- filters for variants that
+  - have a consequence in a pre-defined list
+  - are present with depth > 0
+- extracts NP ID and protein information from the P Dot-notation column
+- adds columns to faciliate addition of reference data
 
 The following variant consequences are included:
 
-  - frameshift_variant
-  - inframe_deletion
-  - inframe_insertion
-  - missense_variant
-  - missense_variant:splice_region_variant
-  - splice_acceptor_variant
-  - splice_donor_variant
-  - splice_donor_variant:intron_variant
-  - start_lost
-  - stop_gained
-  - stop_gained:splice_region_variant
-  - stop_lost
-
-To use the function:
+- frameshift_variant
+- inframe_deletion
+- inframe_insertion
+- missense_variant
+- missense_variant:splice_region_variant
+- splice_acceptor_variant
+- splice_donor_variant
+- splice_donor_variant:intron_variant
+- start_lost
+- stop_gained
+- stop_gained:splice_region_variant
+- stop_lost
 
 ```r
-processed_small_variant_df <- process_small_variant_data(small_variant_df)
+# filter small variant data frame as described above
+small_variants_with_filtered <- small_variant_df %>%
+  process_small_variant_data()
 ```
 
-#### Adding reference data
-
-Reference data can be added to the small variant data frame.
+The package also provides filtering functions for filterting out or keeping variants with specified consequences:
 
 ```r
-ref_data_filepath <- "test_data/TSO_Reference.xlsx"
-flowcell_barcode <- str_extract(cvo_data_dir, "AH.+XY")
-reference_data <- read_reference(ref_data_filepath)
+# filter out (remove) variants from data frame that have any of the specified consequences
+# in this case remove all intronic variants
+consequences <- c("intron_variant")
+filter_consequences(small_variant_df, consequences, "consequence_s")
+
+# keep variants from data frame that have any of the specified consequences
+# in this case keep all missense variants
+consequences <- c("missense_variant")
+keep_consequences(small_variant_df, consequences, "consequence_s")
 ```
 
-#### Plotting
+If your consequences are in a different column (other than `consequence_s`) please specify the name as a third argument.
 
-Plotting functions are also included. These are:
+You can also apply filters based on other properties such as the read depth of the determined variant:
 
-- Plot AF per variant consequence
-- Plot AF KDE per sample
-- Plot AF histogram per sample
+```r
+# keep all small variants that have a depth HIGHER than 100
+small_variants_with_filtered <- small_variant_df %>%
+  filter_depth(100)
+```
+
+The other filterting functions that can be applied on your small variant data frame if it has the corresponding columns are the following:
+
+- filter_germline_db 
+- filter_germline_proxi
+- filter_for_cosmic_id
+- filter_for_Included_in_TMB
+
+### Plotting
+
+*TSO500R(eader)* also provides some (basic) plotting functions. The following functions exist in the current version:
+
+- plot allele frequency per variant consequence
+- plot allele frequency kernel density estimate (KDE) per sample
+- plot allele frequeny histogram per sample
 
 The basic usage is as follows:
 
@@ -113,35 +267,40 @@ plot_af_per_variant_consequence(small_variant_df) %>%
   add_common_theme_elements()
 ```
 
-Example
+We also provide functionality for generating basic OncoPrint plots. If you need specific more complex annotations, we recommend to use the OncoPrint functionality directly.
+
 ```r
-ref_data_filepath <- "test_data/TSO_Reference.xlsx"
-flowcell_barcode <- str_extract(cvo_data_dir, "AH.+XY")
+# prepare matrix based on small variant data frame
+df_for_oncoprint <- prepare_dataframe_for_oncoprint(small_variant_df_filtered, "sample_id", "gene", "consequence_s")
 
-ref <- read_reference(ref_data_filepath)
-
-small_variant_df <- read_small_variants(cvo_data) %>%
-  process_small_variant_data() #%>%
-  #add_reference_data(reference_data_list = ref)
-
-
-metrics_df <- get_metrics_df(cvo_data)
-tmb_metric_names <- c("total_tmb", "coding_region_size_in_megabases", "number_of_passing_eligible_variants")
-msi_metric_names <- c("usable_msi_sites", "total_msi_sites_unstable", "percent_unstable_msi_sites")
-
-data_to_write <- list(metrics_df %>% select(, all_of(msi_metric_names)),
-                      metrics_df %>% select(sample_id, all_of(tmb_metric_names)),
-                      small_variant_df)
-
-names(data_to_write) <- paste0(flowcell_barcode, c("_MSI", "_TMB", "_Nonsyn"))
-
-write_workbook("test", data_frames = data_to_write, sheet_names = names(data_to_write))
+# call function to generate OncoPrint plot
+# alter_list: list with alter_graphics functions for variant types
+# variant_colors: list of defined colors for variant types
+# heatmap_legend: list containing legend specs (title, at, labels)
+plot_onco_print(variant_matrix, "your favorite column title", alter_list, variant_colors, heatmap_legend)
 ```
 
-#### Multiple files
+Please refer to the [OncoPrint documentation](https://jokergoo.github.io/ComplexHeatmap-reference/book/oncoprint.html)  for details.
 
-### Processing
+### Other Convenience Functions
 
-Alternative
+If we need to extract the counts of the different variant types from a list of `combined.variant.output` objects, you can use the following function which will return a data frame of counts per sample.
 
-### Reference data
+```r
+# get count data frame on variant type for list of `combined.variant.output` objects
+get_count_df <- function(cvo_data)
+```
+
+If you want to use your TSO500 data for generating an [OncoPrint](https://jokergoo.github.io/ComplexHeatmap-reference/book/oncoprint.html) plot, you can use the following function to prepare the data accordingly.
+
+```r
+# make sure that your small variant data frame does not have empty fields/ NAs in the needed columns
+# you do not have to use the same function as in this example
+small_variant_df_filtered <- read_small_variants(cvo_data) %>%
+  process_and_filter_small_variant_data()
+
+# run function on small variant data frame
+# if the needed columns have the same name as here you do not have to define them explicitly since these are the default values
+# the columns are id (e.g. sample), gene, and variant type 
+df_for_oncoprint <- prepare_dataframe_for_oncoprint(small_variant_df_filtered, "sample_id", "gene", "consequence_s")
+```


### PR DESCRIPTION
This
- adds more detailed documentation
- removes the hardcoded indices for parsing the CombinedVariantOutput files to make it more robust to changes
- introduces a variable for local_app to specify for the CombinedVariantOutput parser whether the data is coming from local_app or DRAGEN (one more table)
- introduces some more minor changes.